### PR TITLE
Install XDebug on remaining versions

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -2,6 +2,8 @@ FROM yappabe/php:5.3
 
 ENV ENVIRONMENT ci
 
+RUN apt-get install -y php5-xdebug
+
 RUN wget -c https://phar.phpunit.de/phpcpd.phar \
       -P /usr/local/bin/ && \
       ln -s /usr/local/bin/phpcpd.phar /usr/local/bin/phpcpd && \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,6 +2,8 @@ FROM yappabe/php:5.6
 
 ENV ENVIRONMENT ci
 
+RUN apt-get install -y php5-xdebug
+
 RUN wget -c http://www.phpdoc.org/phpDocumentor.phar \
       -P /usr/local/bin/ && \
       ln -s /usr/local/bin/phpDocumentor.phar /usr/local/bin/phpDocumentor && \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -2,6 +2,8 @@ FROM yappabe/php:7.0
 
 ENV ENVIRONMENT ci
 
+RUN apt-get install -y php7.0-xdebug
+
 RUN wget -c http://www.phpdoc.org/phpDocumentor.phar \
       -P /usr/local/bin/ && \
       ln -s /usr/local/bin/phpDocumentor.phar /usr/local/bin/phpDocumentor && \


### PR DESCRIPTION
5.4 already had XDebug installed, add it on the remaining versions. Needed for code coverage.