### PR TITLE
Enable xdebug for php-7.2

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -2,7 +2,7 @@ FROM yappabe/php:7.2
 
 ENV ENVIRONMENT ci
 
-# RUN apt-get install -y php7.2-xdebug
+RUN pecl install xdebug
 
 RUN wget -c http://www.phpdoc.org/phpDocumentor.phar \
       -P /usr/local/bin/ && \

--- a/7.2/php-ci.ini
+++ b/7.2/php-ci.ini
@@ -1,2 +1,3 @@
 opcache.load_comments=1
 zend_optimizerplus.load_comments=1
+zend_extension=xdebug.so


### PR DESCRIPTION
Install and enable xdebug for the PHP 7.2 image in order to generate code coverage reports.