### PR TITLE
Add image with pcov instead of xdebug

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,8 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         php_version: ["5.6", "7.0", "7.1", "7.2", "7.3"]
+        php_pcov_version: ["7.2-pcov", "7.3-pcov"]
 
     steps:
       - uses: actions/checkout@v1
       - name: Build PHP ${{ matrix.php_version }}
         run: docker build ${{ matrix.php_version }}/ --tag php:${{ matrix.php_version }}
+      - name: Build PHP ${{ matrix.php_pcov_version }}
+        run: docker build ${{ matrix.php_pcov_version }}/ --tag php:${{ matrix.php_pcov_version }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,12 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["5.6", "7.0", "7.1", "7.2", "7.3"]
-        php_pcov_version: ["7.2-pcov", "7.3-pcov"]
+        php_version: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.2-pcov", "7.3-pcov"]
 
     steps:
       - uses: actions/checkout@v1
       - name: Build PHP ${{ matrix.php_version }}
         run: docker build ${{ matrix.php_version }}/ --tag php:${{ matrix.php_version }}
-      - name: Build PHP ${{ matrix.php_pcov_version }}
-        run: docker build ${{ matrix.php_pcov_version }}/ --tag php:${{ matrix.php_pcov_version }}

--- a/7.2-pcov/Dockerfile
+++ b/7.2-pcov/Dockerfile
@@ -1,0 +1,38 @@
+FROM yappabe/php:7.2
+
+ENV ENVIRONMENT ci
+
+RUN pecl install pcov
+
+RUN wget -c https://phar.phpunit.de/phploc.phar \
+      -P /usr/local/bin/ && \
+      ln -s /usr/local/bin/phploc.phar /usr/local/bin/phploc && \
+      chmod a+x /usr/local/bin/phploc
+
+RUN wget -c https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar \
+      -P /usr/local/bin/ && \
+      ln -s /usr/local/bin/phpcs.phar /usr/local/bin/phpcs && \
+      chmod a+x /usr/local/bin/phpcs
+
+RUN wget -c https://phar.phpunit.de/phpunit.phar \
+      -P /usr/local/bin/ && \
+      ln -s /usr/local/bin/phpunit.phar /usr/local/bin/phpunit && \
+      chmod a+x /usr/local/bin/phpunit
+
+ADD https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.0/php-cs-fixer.phar /usr/local/bin/php-cs-fixer
+RUN chmod a+x /usr/local/bin/php-cs-fixer
+
+RUN mkdir -p /etc/phpcs && \
+    git clone git://github.com/escapestudios/Symfony2-coding-standard.git /etc/phpcs/Symfony2-coding-standard && \
+    /usr/local/bin/phpcs --config-set installed_paths /etc/phpcs/Symfony2-coding-standard
+
+COPY php-ci.ini    /etc/php/7.2/fpm/conf.d/20-php-ci.ini
+COPY php-ci.ini    /etc/php/7.2/cli/conf.d/20-php-ci.ini
+
+RUN  \
+      phploc --version && \
+      phpcs --version && \
+      phpunit --version && \
+      php-cs-fixer --version
+
+ENTRYPOINT []

--- a/7.2-pcov/php-ci.ini
+++ b/7.2-pcov/php-ci.ini
@@ -1,0 +1,3 @@
+opcache.load_comments=1
+zend_optimizerplus.load_comments=1
+pcov.enabled=1

--- a/7.3-pcov/Dockerfile
+++ b/7.3-pcov/Dockerfile
@@ -1,0 +1,32 @@
+FROM yappabe/php:7.3
+
+ENV ENVIRONMENT ci
+
+RUN pecl install pcov
+
+RUN wget -c https://phar.phpunit.de/phploc.phar \
+      -P /usr/local/bin/ && \
+      ln -s /usr/local/bin/phploc.phar /usr/local/bin/phploc && \
+      chmod a+x /usr/local/bin/phploc
+
+RUN wget -c https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar \
+      -P /usr/local/bin/ && \
+      ln -s /usr/local/bin/phpcs.phar /usr/local/bin/phpcs && \
+      chmod a+x /usr/local/bin/phpcs
+
+ADD https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.0/php-cs-fixer.phar /usr/local/bin/php-cs-fixer
+RUN chmod a+x /usr/local/bin/php-cs-fixer
+
+RUN mkdir -p /etc/phpcs && \
+    git clone git://github.com/escapestudios/Symfony2-coding-standard.git /etc/phpcs/Symfony2-coding-standard && \
+    /usr/local/bin/phpcs --config-set installed_paths /etc/phpcs/Symfony2-coding-standard
+
+COPY php-ci.ini    /etc/php/7.3/fpm/conf.d/20-php-ci.ini
+COPY php-ci.ini    /etc/php/7.3/cli/conf.d/20-php-ci.ini
+
+RUN  \
+      phploc --version && \
+      phpcs --version && \
+      php-cs-fixer --version
+
+ENTRYPOINT []

--- a/7.3-pcov/php-ci.ini
+++ b/7.3-pcov/php-ci.ini
@@ -1,0 +1,3 @@
+opcache.load_comments=1
+zend_optimizerplus.load_comments=1
+pcov.enabled=1


### PR DESCRIPTION
This PR adds 2 new docker images for 7.2 and 7.3 containing the pcov extension instead of xdebug.